### PR TITLE
Adds keypair from/into_bytes implementation

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -35,4 +35,9 @@ jobs:
           args: -- -Dclippy::all
 
       - name: Test
-        run: cargo test
+        uses: actions-rs/tarpaulin@v0.1
+        with:
+          args: "-- --test-threads 1"
+
+      - name: Upload coverage
+        uses: codecov/codecov-action@v1.2.1

--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 ![Continuous Integration](https://github.com/helium/helium-crypto-rs/workflows/Continuous%20Integration/badge.svg)
+[![codecov](https://codecov.io/gh/helium/helium-crypto-rs/branch/main/graph/badge.svg?token=YA02M87E5B)](https://codecov.io/gh/helium/helium-crypto-rs)
 
 ## helium-crypto-rs
 
 This library implements various cryptographic functions used by [Helium
 Blockchain](https://helium.com). This includes creating keypairs for supported
 key types signing messages and verifying messages with public keys. Public keys
-support binary and B58 encode/decoding as used by the Helium blockchain. 
+support binary and B58 encode/decoding as used by the Helium blockchain.
 
-See the library documentation for usage details. 
+See the library documentation for usage details.
 
 ## Using
 

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,1 @@
+nightly

--- a/src/keypair.rs
+++ b/src/keypair.rs
@@ -1,8 +1,15 @@
 use crate::{error, public_key::PublicKey};
 
+#[derive(Debug)]
 pub struct Keypair<C> {
     pub public_key: PublicKey,
     pub(crate) inner: C,
+}
+
+impl<C> PartialEq for Keypair<C> {
+    fn eq(&self, other: &Self) -> bool {
+        self.public_key == other.public_key
+    }
 }
 
 pub trait Sign {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@ pub const KEYTYPE_ECC_COMPACT: u8 = 0;
 /// slice. The output slice is assumed to be of the right minimum size and
 /// implementors are expected to panic otherwise.
 pub trait IntoBytes {
-    fn into_bytes(&self, output: &mut [u8]);
+    fn bytes_into(&self, output: &mut [u8]);
 }
 
 /// Create an instance of the implementor from a given byte slice.

--- a/src/public_key.rs
+++ b/src/public_key.rs
@@ -11,11 +11,13 @@ pub trait Verify {
 pub const PUBLIC_KEY_LENGTH: usize = 33;
 
 /// A public key representing any of the supported public key types.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum PublicKey {
     EccCompact(crate::ecc_compact::PublicKey),
     Ed25519(crate::ed25519::PublicKey),
 }
+
+impl Eq for PublicKey {}
 
 impl FromBytes for PublicKey {
     fn from_bytes(bytes: &[u8]) -> error::Result<Self> {
@@ -44,7 +46,7 @@ impl std::str::FromStr for PublicKey {
     type Err = error::Error;
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         let data = bs58::decode(s).with_check(Some(0)).into_vec()?;
-        Ok(Self::from_bytes(&data[1..])?)
+        Self::from_bytes(&data[1..])
     }
 }
 
@@ -54,11 +56,11 @@ impl std::fmt::Display for PublicKey {
         match self {
             Self::Ed25519(key) => {
                 data[1] = KEYTYPE_ED25519;
-                key.into_bytes(&mut data[2..]);
+                key.bytes_into(&mut data[2..]);
             }
             Self::EccCompact(key) => {
                 data[1] = KEYTYPE_ECC_COMPACT;
-                key.into_bytes(&mut data[2..]);
+                key.bytes_into(&mut data[2..]);
             }
         }
         let encoded = bs58::encode(data.as_ref()).with_check().into_string();


### PR DESCRIPTION
This  does _not_ implement the higher level keypair independent encoding used by the wallet