### PR TITLE
Swap ed25519_dalek crate for ed25519_dalek_bip32.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,8 @@ thiserror = "1"
 bs58 = {version = "0.4", features=["check"]}
 signature = "*"
 rand_core = { version = "0.6", features = ["getrandom"] }
-ed25519-dalek = { git = "https://github.com/helium/ed25519-dalek", branch = "madninja/bump_rand" }
+# TODO: Change this to the appropriate git repo. This fork has only one change in it, to depend on the helium fork of ed25519_dalek that the current code does.
+ed25519-dalek-bip32 = { git = "https://github.com/kellybyrd/ed25519-dalek-bip32" }
 p256 = { git = "https://github.com/helium/elliptic-curves", branch="rg/compact", default-features=false, features=["arithmetic", "ecdsa", "sha256", "zeroize"] }
 
 [dev-dependencies]
@@ -20,5 +21,3 @@ sha2 = "0"
 
 [patch.crates-io]
 elliptic-curve = { git = "https://github.com/helium/traits.git", branch = "rg/compact" }
-
-

--- a/src/ed25519/mod.rs
+++ b/src/ed25519/mod.rs
@@ -1,4 +1,5 @@
 use crate::*;
+use ed25519_dalek_bip32::ed25519_dalek;
 use std::convert::TryFrom;
 
 #[derive(Debug, PartialEq, Clone)]


### PR DESCRIPTION
In order to add support for importing helium-ledger-app seed phrases,
helium-wallet-rs needs to be able to generate BIP-32 public keys. It
seems like the best place to start with that was to add code to do this
in helium-crypto-rs.

This commit is a first step, just swapping out the ed25519_dalek crate
for another which layers in BIP32 support. The existing ed25519_dalek
functionality is still available.

Since this project was depending on specific branch on a Helium fork of
ed25519_dalek, I forked ed25519_dalek_bip32 so it would use the same
Helium version of the underlying ed25519_dalek crate. I don't think you
should actually merge this pointing to my repo, I'm just using those as
an example so a Helium org maintainer can fork ed25519_dalek_bip32 and
see the small change I made to pull in the right branch on Helium's
fork.