### PR TITLE
Allow ecc_compact construction from a non-compact/compressed key

### DIFF
--- a/src/public_key.rs
+++ b/src/public_key.rs
@@ -128,6 +128,18 @@ impl Verify for PublicKeyRepr {
     }
 }
 
+impl From<ecc_compact::PublicKey> for PublicKey {
+    fn from(v: ecc_compact::PublicKey) -> Self {
+        Self::for_network(Network::MainNet, v)
+    }
+}
+
+impl From<ed25519::PublicKey> for PublicKey {
+    fn from(v: ed25519::PublicKey) -> Self {
+        Self::for_network(Network::MainNet, v)
+    }
+}
+
 impl std::str::FromStr for PublicKey {
     type Err = Error;
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {


### PR DESCRIPTION
Returns an error if the bytes generate a key that is not compactable