### PR TITLE
Allow public keys of variable length by type

### DIFF
--- a/src/ecc_compact/mod.rs
+++ b/src/ecc_compact/mod.rs
@@ -19,6 +19,7 @@ pub struct Keypair {
 }
 
 pub const KEYPAIR_LENGTH: usize = 33;
+pub const PUBLIC_KEY_LENGTH: usize = 33;
 
 pub trait IsCompactable {
     fn is_compactable(&self) -> bool;
@@ -106,8 +107,8 @@ impl Keypair {
         })
     }
 
-    pub fn to_bytes(&self) -> [u8; KEYPAIR_LENGTH] {
-        let mut result = [0u8; KEYPAIR_LENGTH];
+    pub fn to_vec(&self) -> Vec<u8> {
+        let mut result = vec![0u8; KEYPAIR_LENGTH];
         self.bytes_into(&mut result);
         result
     }
@@ -149,6 +150,12 @@ impl Signature {
 
     pub fn to_vec(&self) -> Vec<u8> {
         self.0.to_der().as_bytes().to_vec()
+    }
+}
+
+impl PublicKeySize for PublicKey {
+    fn public_key_size(&self) -> usize {
+        PUBLIC_KEY_LENGTH
     }
 }
 
@@ -219,7 +226,7 @@ mod tests {
     fn bytes_roundtrip() {
         use rand::rngs::OsRng;
         let keypair = Keypair::generate(Network::MainNet, &mut OsRng);
-        let bytes = keypair.to_bytes();
+        let bytes = keypair.to_vec();
         assert_eq!(
             keypair,
             super::Keypair::try_from(&bytes[..]).expect("keypair")

--- a/src/ecc_compact/mod.rs
+++ b/src/ecc_compact/mod.rs
@@ -119,6 +119,10 @@ impl Keypair {
             key_type: KeyType::EccCompact,
         }
     }
+
+    pub fn secret_to_vec(&self) -> Result<Vec<u8>> {
+        Ok(self.secret.to_bytes().as_slice().to_vec())
+    }
 }
 
 impl signature::Signature for Signature {

--- a/src/ed25519/mod.rs
+++ b/src/ed25519/mod.rs
@@ -84,6 +84,10 @@ impl Keypair {
             key_type: KeyType::Ed25519,
         }
     }
+
+    pub fn secret_to_vec(&self) -> Result<Vec<u8>> {
+        Ok(self.secret.secret.as_bytes().to_vec())
+    }
 }
 
 impl signature::Signature for Signature {

--- a/src/ed25519/mod.rs
+++ b/src/ed25519/mod.rs
@@ -14,6 +14,7 @@ pub struct Keypair {
 }
 
 pub const KEYPAIR_LENGTH: usize = ed25519_dalek::KEYPAIR_LENGTH + 1;
+pub const PUBLIC_KEY_LENGTH: usize = ed25519_dalek::PUBLIC_KEY_LENGTH + 1;
 
 impl keypair::Sign for Keypair {
     fn sign(&self, msg: &[u8]) -> Result<Vec<u8>> {
@@ -71,8 +72,8 @@ impl Keypair {
         })
     }
 
-    pub fn to_bytes(&self) -> [u8; KEYPAIR_LENGTH] {
-        let mut result = [0u8; KEYPAIR_LENGTH];
+    pub fn to_vec(&self) -> Vec<u8> {
+        let mut result = vec![0u8; KEYPAIR_LENGTH];
         self.bytes_into(&mut result);
         result
     }
@@ -142,6 +143,12 @@ impl TryFrom<&[u8]> for Signature {
     }
 }
 
+impl PublicKeySize for PublicKey {
+    fn public_key_size(&self) -> usize {
+        PUBLIC_KEY_LENGTH
+    }
+}
+
 impl public_key::Verify for PublicKey {
     fn verify(&self, msg: &[u8], signature: &[u8]) -> std::result::Result<(), Error> {
         use ed25519_dalek::Verifier;
@@ -208,7 +215,7 @@ mod tests {
     fn bytes_roundtrip() {
         use rand::rngs::OsRng;
         let keypair = Keypair::generate(Network::MainNet, &mut OsRng);
-        let bytes = keypair.to_bytes();
+        let bytes = keypair.to_vec();
         assert_eq!(
             keypair,
             super::Keypair::try_from(&bytes[..]).expect("keypair")
@@ -216,7 +223,7 @@ mod tests {
         assert_eq!(keypair.public_key.network, Network::MainNet);
         // Testnet
         let keypair = Keypair::generate(Network::TestNet, &mut OsRng);
-        let bytes = keypair.to_bytes();
+        let bytes = keypair.to_vec();
         assert_eq!(
             keypair,
             super::Keypair::try_from(&bytes[..]).expect("keypair")

--- a/src/keypair.rs
+++ b/src/keypair.rs
@@ -66,18 +66,10 @@ impl Keypair {
         }
     }
 
-    pub fn to_bytes(&self) -> Vec<u8> {
+    pub fn to_vec(&self) -> Vec<u8> {
         match self {
-            Self::Ed25519(keypair) => {
-                let mut bytes = [0u8; ed25519::KEYPAIR_LENGTH];
-                keypair.bytes_into(&mut bytes);
-                bytes.to_vec()
-            }
-            Self::EccCompact(keypair) => {
-                let mut bytes = [0u8; ecc_compact::KEYPAIR_LENGTH];
-                keypair.bytes_into(&mut bytes);
-                bytes.to_vec()
-            }
+            Self::Ed25519(keypair) => keypair.to_vec(),
+            Self::EccCompact(keypair) => keypair.to_vec(),
         }
     }
 }
@@ -112,7 +104,7 @@ mod tests {
 
     fn bytes_roundtrip(key_tag: KeyTag) {
         let keypair = Keypair::generate(key_tag, &mut OsRng);
-        let bytes = keypair.to_bytes();
+        let bytes = keypair.to_vec();
         assert_eq!(
             keypair,
             super::Keypair::try_from(&bytes[..]).expect("keypair")

--- a/src/keypair.rs
+++ b/src/keypair.rs
@@ -8,10 +8,6 @@ pub trait Sign {
     fn sign(&self, msg: &[u8]) -> Result<Vec<u8>>;
 }
 
-pub(crate) trait KeypairLength {
-    const KEYPAIR_LENGTH: usize;
-}
-
 #[derive(PartialEq, Debug)]
 pub enum Keypair {
     Ed25519(ed25519::Keypair),
@@ -70,6 +66,13 @@ impl Keypair {
         match self {
             Self::Ed25519(keypair) => keypair.to_vec(),
             Self::EccCompact(keypair) => keypair.to_vec(),
+        }
+    }
+
+    pub fn secret_to_vec(&self) -> Result<Vec<u8>> {
+        match self {
+            Self::Ed25519(keypair) => keypair.secret_to_vec(),
+            Self::EccCompact(keypair) => keypair.secret_to_vec(),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@ pub mod public_key;
 mod keypair;
 pub use error::{Error, Result};
 pub use keypair::{Keypair, Sign};
-pub use public_key::{PublicKey, Verify, PUBLIC_KEY_LENGTH};
+pub use public_key::{PublicKey, PublicKeySize, Verify};
 use std::{
     convert::{From, TryFrom, TryInto},
     fmt,


### PR DESCRIPTION
To allow for other keytypes the fixed public key bytesize is no longer viable. This introduces a PublicKeySize trait which implementations can use to indicate their binary size