### PR TITLE
impl Hash for PublicKey

### DIFF
--- a/src/ecc_compact/mod.rs
+++ b/src/ecc_compact/mod.rs
@@ -4,9 +4,13 @@ use p256::{
     elliptic_curve::{ecdh, sec1::ToCompactEncodedPoint, weierstrass::DecompactPoint},
     FieldBytes,
 };
-use std::{convert::TryFrom, ops::Deref};
+use std::{
+    convert::TryFrom,
+    hash::{Hash, Hasher},
+    ops::Deref,
+};
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, Clone)]
 pub struct PublicKey(pub(crate) p256::PublicKey);
 
 pub struct SharedSecret(pub(crate) p256::ecdh::SharedSecret);
@@ -219,6 +223,23 @@ impl IntoBytes for PublicKey {
             .to_compact_encoded_point()
             .expect("compact point");
         output.copy_from_slice(&encoded.as_bytes()[1..])
+    }
+}
+
+impl PartialEq for PublicKey {
+    fn eq(&self, other: &Self) -> bool {
+        self.0 == other.0
+    }
+}
+
+impl Hash for PublicKey {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        let encoded = self
+            .0
+            .as_affine()
+            .to_compact_encoded_point()
+            .expect("compact point");
+        state.write(encoded.as_bytes())
     }
 }
 

--- a/src/ecc_compact/mod.rs
+++ b/src/ecc_compact/mod.rs
@@ -215,21 +215,14 @@ impl TryFrom<&[u8]> for PublicKey {
     }
 }
 
-impl PublicKey {
-    // this unreachable hint only holds if every constructor of PublicKey
-    // verifies "is_compactable".
-    fn to_encoded_point(&self) -> p256::EncodedPoint {
-        use std::hint::unreachable_unchecked;
-        self.0
-            .as_affine()
-            .to_compact_encoded_point()
-            .unwrap_or_else(|| unsafe { unreachable_unchecked() })
-    }
-}
-
 impl IntoBytes for PublicKey {
     fn bytes_into(&self, output: &mut [u8]) {
-        let encoded = self.to_encoded_point();
+        use std::hint::unreachable_unchecked;
+        let encoded = self
+            .0
+            .as_affine()
+            .to_compact_encoded_point()
+            .unwrap_or_else(|| unsafe { unreachable_unchecked() });
         output.copy_from_slice(&encoded.as_bytes()[1..])
     }
 }

--- a/src/ecc_compact/mod.rs
+++ b/src/ecc_compact/mod.rs
@@ -242,7 +242,8 @@ impl PartialEq for PublicKey {
 
 impl Hash for PublicKey {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        let encoded = self.to_encoded_point();
+        use p256::elliptic_curve::sec1::ToEncodedPoint;
+        let encoded = self.0.as_affine().to_encoded_point(false);
         state.write(encoded.as_bytes())
     }
 }

--- a/src/ed25519/mod.rs
+++ b/src/ed25519/mod.rs
@@ -3,6 +3,7 @@ use std::{
     convert::TryFrom,
     hash::{Hash, Hasher},
 };
+
 #[derive(Debug, Clone)]
 pub struct PublicKey(ed25519_dalek::PublicKey);
 

--- a/src/ed25519/mod.rs
+++ b/src/ed25519/mod.rs
@@ -1,7 +1,9 @@
 use crate::*;
-use std::convert::TryFrom;
-
-#[derive(Debug, PartialEq, Clone)]
+use std::{
+    convert::TryFrom,
+    hash::{Hash, Hasher},
+};
+#[derive(Debug, Clone)]
 pub struct PublicKey(ed25519_dalek::PublicKey);
 
 #[derive(Debug, PartialEq, Clone)]
@@ -165,6 +167,18 @@ impl public_key::Verify for PublicKey {
 impl IntoBytes for PublicKey {
     fn bytes_into(&self, output: &mut [u8]) {
         output.copy_from_slice(self.as_ref())
+    }
+}
+
+impl PartialEq for PublicKey {
+    fn eq(&self, other: &Self) -> bool {
+        self.0 == other.0
+    }
+}
+
+impl Hash for PublicKey {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        state.write(self.as_ref())
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,12 +37,13 @@ pub use public_key::{PublicKey, PublicKeySize, Verify};
 use std::{
     convert::{From, TryFrom, TryInto},
     fmt,
+    hash::Hash,
     str::FromStr,
 };
 
 /// Keys are generated for a given network. Supported networks are mainnet and
 /// testnet. The default network is mainnet.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Hash)]
 pub enum Network {
     MainNet,
     TestNet,

--- a/src/public_key.rs
+++ b/src/public_key.rs
@@ -334,7 +334,7 @@ mod tests {
         let mut bytes_ed25519 = default_bytes();
         bytes_ed25519[0] = 0x01;
 
-        let public_key_ecccompact =parse_pubkey(&bytes_ecccompact);
+        let public_key_ecccompact = parse_pubkey(&bytes_ecccompact);
         let public_key_ed25519 = parse_pubkey(&bytes_ed25519);
         // we verify the different keytypes
         assert_eq!(public_key_ecccompact.key_type(), KeyType::EccCompact);

--- a/src/public_key.rs
+++ b/src/public_key.rs
@@ -282,7 +282,7 @@ mod tests {
     use std::collections::hash_map::DefaultHasher;
     use std::hash::{Hash, Hasher};
 
-    fn default_bytes() -> [u8; 33] {
+    const fn default_bytes() -> [u8; 33] {
         hex!("008f23e96ab6bbff48c8923cac831dc97111bcf33dba9f5a8539c00f9d93551af1")
     }
 

--- a/src/public_key.rs
+++ b/src/public_key.rs
@@ -3,8 +3,7 @@
 //! since a client will need to be able to parse and use a public key from any
 //! keypair.
 use crate::*;
-use std::convert::TryFrom;
-
+use std::{convert::TryFrom, hash::Hash};
 ///Verify a given message against a given signature slice. Public keys are
 ///expected to implemt this trait to verify signed messages.
 pub trait Verify {
@@ -24,7 +23,7 @@ pub trait PublicKeySize {
 /// network.
 ///
 /// Public keys can convert to and from their binary and base58 representation
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct PublicKey {
     /// The network this public key is valid for
     pub network: Network,
@@ -32,7 +31,7 @@ pub struct PublicKey {
 }
 
 /// Holds the actual representation of all supported public key types.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub(crate) enum PublicKeyRepr {
     EccCompact(ecc_compact::PublicKey),
     Ed25519(ed25519::PublicKey),

--- a/src/public_key.rs
+++ b/src/public_key.rs
@@ -4,6 +4,7 @@
 //! keypair.
 use crate::*;
 use std::{convert::TryFrom, hash::Hash};
+
 ///Verify a given message against a given signature slice. Public keys are
 ///expected to implemt this trait to verify signed messages.
 pub trait Verify {

--- a/src/public_key.rs
+++ b/src/public_key.rs
@@ -287,7 +287,7 @@ mod tests {
         ]
     }
 
-    // move the key to make sure we don't accidentally hash the same thing twice in tests
+    // move the key so as to consume it and avoid accidentally hashing the same thing twice in tests
     fn pubkey_hash(pubkey: PublicKey) -> u64 {
         let mut hasher = DefaultHasher::new();
         pubkey.hash(&mut hasher);

--- a/src/public_key.rs
+++ b/src/public_key.rs
@@ -282,9 +282,7 @@ mod tests {
     use std::collections::hash_map::DefaultHasher;
     use std::hash::{Hash, Hasher};
 
-    const fn default_bytes() -> [u8; 33] {
-        hex!("008f23e96ab6bbff48c8923cac831dc97111bcf33dba9f5a8539c00f9d93551af1")
-    }
+    const DEFAULT_BYTES: [u8; 33] = hex!("008f23e96ab6bbff48c8923cac831dc97111bcf33dba9f5a8539c00f9d93551af1");
 
     // move the key so as to consume it and avoid accidentally hashing the same thing twice in tests
     fn pubkey_hash(pubkey: PublicKey) -> u64 {
@@ -299,7 +297,7 @@ mod tests {
 
     #[test]
     fn hash_match() {
-        let bytes = default_bytes();
+        let bytes = DEFAULT_BYTES;
         let public_key_one = parse_pubkey(&bytes);
         let public_key_two = parse_pubkey(&bytes);
 
@@ -311,9 +309,9 @@ mod tests {
 
     #[test]
     fn hash_diff_network() {
-        let bytes_mainnet = default_bytes();
+        let bytes_mainnet = DEFAULT_BYTES;
 
-        let mut bytes_testnet = default_bytes();
+        let mut bytes_testnet = DEFAULT_BYTES;
         bytes_testnet[0] = 0x10;
 
         let public_key_mainnet = parse_pubkey(&bytes_mainnet);
@@ -330,8 +328,8 @@ mod tests {
 
     #[test]
     fn hash_diff_keytype() {
-        let bytes_ecccompact = default_bytes();
-        let mut bytes_ed25519 = default_bytes();
+        let bytes_ecccompact = DEFAULT_BYTES;
+        let mut bytes_ed25519 = DEFAULT_BYTES;
         bytes_ed25519[0] = 0x01;
 
         let public_key_ecccompact = parse_pubkey(&bytes_ecccompact);
@@ -348,8 +346,8 @@ mod tests {
 
     #[test]
     fn hash_one_byte_diff() {
-        let bytes_one = default_bytes();
-        let mut bytes_two = default_bytes();
+        let bytes_one = DEFAULT_BYTES;
+        let mut bytes_two = DEFAULT_BYTES;
         bytes_two[8] = 0xAB;
 
         let public_key_one = parse_pubkey(&bytes_one);

--- a/src/public_key.rs
+++ b/src/public_key.rs
@@ -277,9 +277,9 @@ mod tests {
         assert_eq!(public_key.to_string(), B58.to_string())
     }
 
+    use hex_literal::hex;
     use std::collections::hash_map::DefaultHasher;
     use std::hash::{Hash, Hasher};
-    use hex_literal::hex;
 
     fn default_bytes() -> [u8; 33] {
         hex!("008f23e96ab6bbff48c8923cac831dc97111bcf33dba9f5a8539c00f9d93551af1")
@@ -292,11 +292,15 @@ mod tests {
         hasher.finish()
     }
 
+    fn parse_pubkey(bytes: &[u8; 33]) -> PublicKey {
+        PublicKey::from_bytes(&bytes).expect("failed to parse bytes as publickey")
+    }
+
     #[test]
     fn hash_match() {
         let bytes = default_bytes();
-        let public_key_one = PublicKey::from_bytes(&bytes).unwrap();
-        let public_key_two = PublicKey::from_bytes(&bytes).unwrap();
+        let public_key_one = parse_pubkey(&bytes);
+        let public_key_two = parse_pubkey(&bytes);
 
         let hash_one = pubkey_hash(public_key_one);
         let hash_two = pubkey_hash(public_key_two);
@@ -311,8 +315,8 @@ mod tests {
         let mut bytes_testnet = default_bytes();
         bytes_testnet[0] = 0x10;
 
-        let public_key_mainnet = PublicKey::from_bytes(&bytes_mainnet).unwrap();
-        let public_key_testnet = PublicKey::from_bytes(&bytes_testnet).unwrap();
+        let public_key_mainnet = parse_pubkey(&bytes_mainnet);
+        let public_key_testnet = parse_pubkey(&bytes_testnet);
         // we verify the different networks
         assert_eq!(public_key_mainnet.network, Network::MainNet);
         assert_eq!(public_key_testnet.network, Network::TestNet);
@@ -329,8 +333,8 @@ mod tests {
         let mut bytes_ed25519 = default_bytes();
         bytes_ed25519[0] = 0x01;
 
-        let public_key_ecccompact = PublicKey::from_bytes(&bytes_ecccompact).unwrap();
-        let public_key_ed25519 = PublicKey::from_bytes(&bytes_ed25519).unwrap();
+        let public_key_ecccompact =parse_pubkey(&bytes_ecccompact);
+        let public_key_ed25519 = parse_pubkey(&bytes_ed25519);
         // we verify the different keytypes
         assert_eq!(public_key_ecccompact.key_type(), KeyType::EccCompact);
         assert_eq!(public_key_ed25519.key_type(), KeyType::Ed25519);
@@ -347,8 +351,8 @@ mod tests {
         let mut bytes_two = default_bytes();
         bytes_two[8] = 0xAB;
 
-        let public_key_one = PublicKey::from_bytes(&bytes_one).unwrap();
-        let public_key_two = PublicKey::from_bytes(&bytes_two).unwrap();
+        let public_key_one = parse_pubkey(&bytes_one);
+        let public_key_two = parse_pubkey(&bytes_two);
 
         let hash_one = pubkey_hash(public_key_one);
         let hash_two = pubkey_hash(public_key_two);

--- a/src/public_key.rs
+++ b/src/public_key.rs
@@ -279,12 +279,10 @@ mod tests {
 
     use std::collections::hash_map::DefaultHasher;
     use std::hash::{Hash, Hasher};
+    use hex_literal::hex;
 
     fn default_bytes() -> [u8; 33] {
-        [
-            0x00, 143, 35, 233, 106, 182, 187, 255, 72, 200, 146, 60, 172, 131, 29, 201, 113, 17,
-            188, 243, 61, 186, 159, 90, 133, 57, 192, 15, 157, 147, 85, 26, 241,
-        ]
+        hex!("008f23e96ab6bbff48c8923cac831dc97111bcf33dba9f5a8539c00f9d93551af1")
     }
 
     // move the key so as to consume it and avoid accidentally hashing the same thing twice in tests
@@ -297,7 +295,6 @@ mod tests {
     #[test]
     fn hash_match() {
         let bytes = default_bytes();
-
         let public_key_one = PublicKey::from_bytes(&bytes).unwrap();
         let public_key_two = PublicKey::from_bytes(&bytes).unwrap();
 

--- a/src/public_key.rs
+++ b/src/public_key.rs
@@ -282,7 +282,8 @@ mod tests {
     use std::collections::hash_map::DefaultHasher;
     use std::hash::{Hash, Hasher};
 
-    const DEFAULT_BYTES: [u8; 33] = hex!("008f23e96ab6bbff48c8923cac831dc97111bcf33dba9f5a8539c00f9d93551af1");
+    const DEFAULT_BYTES: [u8; 33] =
+        hex!("008f23e96ab6bbff48c8923cac831dc97111bcf33dba9f5a8539c00f9d93551af1");
 
     // move the key so as to consume it and avoid accidentally hashing the same thing twice in tests
     fn pubkey_hash(pubkey: PublicKey) -> u64 {


### PR DESCRIPTION
It's useful to be able to use PublicKey as a key for HashMap and this enables that. Rust doesn't like it when you derive PartialEq but then implement Hash by hand, thus PartialEq is also derived.