### PR TITLE
Truncate input when constructing keypairs from bytes

### DIFF
--- a/src/ecc_compact/mod.rs
+++ b/src/ecc_compact/mod.rs
@@ -60,7 +60,8 @@ impl TryFrom<&[u8]> for Keypair {
     type Error = Error;
     fn try_from(input: &[u8]) -> Result<Self> {
         let network = Network::try_from(input[0])?;
-        let secret = p256::SecretKey::from_bytes(&input[1..])?;
+        let secret =
+            p256::SecretKey::from_bytes(&input[1..usize::min(input.len(), KEYPAIR_LENGTH)])?;
         let public_key =
             public_key::PublicKey::for_network(network, PublicKey(secret.public_key()));
         Ok(Keypair {

--- a/src/ed25519/mod.rs
+++ b/src/ed25519/mod.rs
@@ -29,7 +29,8 @@ impl TryFrom<&[u8]> for Keypair {
 
     fn try_from(input: &[u8]) -> Result<Self> {
         let network = Network::try_from(input[0])?;
-        let secret = ed25519_dalek::Keypair::from_bytes(&input[1..])?;
+        let secret =
+            ed25519_dalek::Keypair::from_bytes(&input[1..usize::min(input.len(), KEYPAIR_LENGTH)])?;
         let public_key = public_key::PublicKey::for_network(network, PublicKey(secret.public));
         Ok(Keypair {
             network,


### PR DESCRIPTION
The upstream crypto crates return `Err` when the input slice is not exactly what they expect. This is a problem when the input had unrelated trailing data. 

A reasonable argument could be made to require consumers of this crate to right-size the input slice before calling `Keypair::try_from`, but that requires knowledge about the crypto crates two dependencies deep.