### PR TITLE
Custom Debug for PublicKey

### DIFF
--- a/src/public_key.rs
+++ b/src/public_key.rs
@@ -24,11 +24,28 @@ pub trait PublicKeySize {
 /// network.
 ///
 /// Public keys can convert to and from their binary and base58 representation
-#[derive(Debug, Clone, PartialEq, Hash)]
+#[derive(Clone, PartialEq, Hash)]
 pub struct PublicKey {
     /// The network this public key is valid for
     pub network: Network,
     inner: PublicKeyRepr,
+}
+
+impl fmt::Debug for PublicKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let r#type = match self.inner {
+            PublicKeyRepr::Ed25519(_) => "ed25519",
+            PublicKeyRepr::EccCompact(_) => "ecc_compact",
+        };
+        let output = format!(
+            "PublicKey {{ \
+        network: {:?}, type: {}, base58: {} }}",
+            &self.network,
+            &r#type,
+            &self.to_string()
+        );
+        f.write_str(&output)
+    }
 }
 
 /// Holds the actual representation of all supported public key types.
@@ -357,5 +374,19 @@ mod tests {
         let hash_one = pubkey_hash(public_key_one);
         let hash_two = pubkey_hash(public_key_two);
         assert_ne!(hash_one, hash_two);
+    }
+
+    #[test]
+    fn custom_debug() {
+        let public_key = PublicKey::from_bytes(DEFAULT_BYTES).unwrap();
+
+        let debug = format!("{:?}", public_key);
+        assert_eq!(
+            debug,
+            "PublicKey { \
+                        network: MainNet, type: ecc_compact, \
+                        base58: 11263KvqW3GZPAvag5sQYtBJSjb25azSTSwoi5Tza9kboaLRxcsv \
+                    }"
+        );
     }
 }

--- a/src/public_key.rs
+++ b/src/public_key.rs
@@ -39,7 +39,7 @@ impl fmt::Debug for PublicKey {
         };
         let output = format!(
             "PublicKey {{ \
-        network: {:?}, type: {}, base58: {} }}",
+        network: {}, type: {}, address: {} }}",
             &self.network,
             &r#type,
             &self.to_string()
@@ -384,8 +384,8 @@ mod tests {
         assert_eq!(
             debug,
             "PublicKey { \
-                        network: MainNet, type: ecc_compact, \
-                        base58: 11263KvqW3GZPAvag5sQYtBJSjb25azSTSwoi5Tza9kboaLRxcsv \
+                        network: mainnet, type: ecc_compact, \
+                        address: 11263KvqW3GZPAvag5sQYtBJSjb25azSTSwoi5Tza9kboaLRxcsv \
                     }"
         );
     }


### PR DESCRIPTION
The default debug implementation for PublicKey is a little unwieldly.

```
PublicKey { network: TestNet, inner: EccCompact(PublicKey(PublicKey { point: AffinePoint { x: FieldElement([17423185708765931505, 12739156735786343028, 14006119074768089362, 16430687618580685745]), y: FieldElement([14104296635496982085, 2754348852290135404, 8063878053854174113, 56785449696037502]), infinity: Choice(0) } })) }

PublicKey { network: TestNet, inner: Ed25519(PublicKey(PublicKey(CompressedEdwardsY: [178, 110, 98, 10, 128, 200, 97, 139, 206, 212, 107, 12, 216, 179, 227, 28, 132, 227, 158, 112, 234, 21, 43, 151, 228, 223, 161, 84, 245, 165, 75, 236]), EdwardsPoint{
    	X: FieldElement51([237893327690221, 1338383917212842, 1575710459761089, 1076778710781406, 1958763189689110]),
    	Y: FieldElement51([501927232302770, 846132089049452, 698800045002447, 2236731282355512, 1905154602650141]),
    	Z: FieldElement51([1, 0, 0, 0, 0]),
    	T: FieldElement51([844317815359499, 1832558785134807, 415178092339209, 2200114320475068, 1026872878790594])
    }))) } }
```

This custom implementation displays it as follows [edited after review]:

```
PublicKey { network: mainnet, type: ecc_compact, address: 11263KvqW3GZPAvag5sQYtBJSjb25azSTSwoi5Tza9kboaLRxcsv }
```
