### PR TITLE
use ed25519-compact

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ signature = "*"
 serde =  {version = "1", features=["derive"]}
 rand_core = { version = "0.6", features = ["getrandom"] }
 sha2 = "0"
-ed25519-dalek = { git = "https://github.com/helium/ed25519-dalek", branch = "madninja/bump_rand" }
+ed25519-compact = {version = "2", features = ["std", "traits"] }
 p256 = { version="0.11", default-features=false, features=["arithmetic", "ecdsa", "sha256", "ecdh"] }
 k256 = { version="0.11", default-features=false, features=["arithmetic", "ecdsa", "sha256", "ecdh"] }
 ecc608-linux = { version = "0", optional = true}

--- a/src/error.rs
+++ b/src/error.rs
@@ -8,6 +8,8 @@ pub enum Error {
     Decode(#[from] DecodeError),
     #[error("elliptic_curve error")]
     EccCompact(p256::elliptic_curve::Error),
+    #[error("ed25519 error")]
+    Ed25519(#[from] ed25519_compact::Error),
     #[error("signature error")]
     Signature(#[from] signature::Error),
     #[error("invalid curve error")]


### PR DESCRIPTION
This switches to use ed25519-compact instead of dalek since it’s more stable and supported by the libsodium authors.