### PR TITLE
Optimize Ord/PartialOrd to not use strings

### DIFF
--- a/src/ecc_compact/mod.rs
+++ b/src/ecc_compact/mod.rs
@@ -180,6 +180,20 @@ impl PublicKeySize for PublicKey {
     const PUBLIC_KEY_SIZE: usize = PUBLIC_KEY_LENGTH;
 }
 
+impl Eq for PublicKey {}
+
+impl PartialOrd for PublicKey {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        self.0.partial_cmp(&other.0)
+    }
+}
+
+impl Ord for PublicKey {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.0.cmp(&other.0)
+    }
+}
+
 impl public_key::Verify for PublicKey {
     fn verify(&self, msg: &[u8], signature: &[u8]) -> Result {
         use signature::Verifier;

--- a/src/ed25519/mod.rs
+++ b/src/ed25519/mod.rs
@@ -160,6 +160,20 @@ impl PublicKeySize for PublicKey {
     const PUBLIC_KEY_SIZE: usize = PUBLIC_KEY_LENGTH;
 }
 
+impl Eq for PublicKey {}
+
+impl PartialOrd for PublicKey {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        self.0.partial_cmp(&other.0)
+    }
+}
+
+impl Ord for PublicKey {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.0.cmp(&other.0)
+    }
+}
+
 impl public_key::Verify for PublicKey {
     fn verify(&self, msg: &[u8], signature: &[u8]) -> Result {
         let signature = Signature::try_from(signature)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,7 @@ use std::{
 
 /// Keys are generated for a given network. Supported networks are mainnet and
 /// testnet. The default network is mainnet.
-#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Deserialize)]
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Deserialize, PartialOrd, Ord)]
 #[serde(rename_all = "lowercase")]
 pub enum Network {
     MainNet,

--- a/src/multisig/mod.rs
+++ b/src/multisig/mod.rs
@@ -55,7 +55,7 @@ impl Error {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Eq)]
 pub struct PublicKey {
     pub(crate) m: u8,
     pub(crate) n: u8,
@@ -274,6 +274,18 @@ impl WriteTo for PublicKey {
 impl PartialEq for PublicKey {
     fn eq(&self, other: &Self) -> bool {
         self.keys_digest == other.keys_digest
+    }
+}
+
+impl PartialOrd for PublicKey {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        self.keys_digest.partial_cmp(&other.keys_digest)
+    }
+}
+
+impl Ord for PublicKey {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.keys_digest.cmp(&other.keys_digest)
     }
 }
 

--- a/src/public_key.rs
+++ b/src/public_key.rs
@@ -42,7 +42,7 @@ impl fmt::Debug for PublicKey {
 }
 
 /// Holds the actual representation of all supported public key types.
-#[derive(Clone, PartialEq, Hash)]
+#[derive(Clone, PartialEq, Hash, PartialOrd, Ord)]
 pub(crate) enum PublicKeyRepr {
     EccCompact(ecc_compact::PublicKey),
     Ed25519(ed25519::PublicKey),
@@ -61,7 +61,12 @@ impl PartialOrd for PublicKey {
 
 impl Ord for PublicKey {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.to_string().cmp(&other.to_string())
+        let network_cmp = self.network.cmp(&other.network);
+        if network_cmp == std::cmp::Ordering::Equal {
+            self.inner.cmp(&other.inner)
+        } else {
+            network_cmp
+        }
     }
 }
 

--- a/src/secp256k1/mod.rs
+++ b/src/secp256k1/mod.rs
@@ -147,6 +147,20 @@ impl PublicKeySize for PublicKey {
     const PUBLIC_KEY_SIZE: usize = PUBLIC_KEY_LENGTH;
 }
 
+impl Eq for PublicKey {}
+
+impl PartialOrd for PublicKey {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        self.0.partial_cmp(&other.0)
+    }
+}
+
+impl Ord for PublicKey {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.0.cmp(&other.0)
+    }
+}
+
 impl Verify for PublicKey {
     fn verify(&self, msg: &[u8], signature: &[u8]) -> Result {
         use signature::Verifier;


### PR DESCRIPTION
This changes PartialOrd and Ord for PublicKey and it’s various inner representation. This _will_ change how keys are sorted in code relying on Ord but so far we’ve not seen any

Fixes #40 