### PR TITLE
pub use solana sdk

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,9 @@ pub mod multisig;
 #[cfg(feature = "multisig")]
 pub use multihash;
 
+#[cfg(feature = "solana")]
+pub use solana_sdk;
+
 pub mod error;
 pub mod public_key;
 pub mod public_key_binary;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,9 +43,6 @@ pub mod multisig;
 #[cfg(feature = "multisig")]
 pub use multihash;
 
-#[cfg(feature = "solana")]
-pub use solana_sdk;
-
 pub mod error;
 pub mod public_key;
 pub mod public_key_binary;

--- a/src/public_key.rs
+++ b/src/public_key.rs
@@ -386,13 +386,18 @@ impl PublicKey {
             PublicKeyRepr::Secp256k1(..) => secp256k1::PUBLIC_KEY_LENGTH,
         }
     }
+
+    #[cfg(feature = "solana")]
+    pub fn to_solana(&self) -> Result<solana_sdk::pubkey::Pubkey> {
+        self.clone().try_into()
+    }
 }
 
 #[cfg(feature = "solana")]
 impl TryFrom<PublicKey> for solana_sdk::pubkey::Pubkey {
-    type Error = error::Error;
+    type Error = Error;
 
-    fn try_from(public_key: PublicKey) -> std::result::Result<Self, Self::Error> {
+    fn try_from(public_key: PublicKey) -> Result<Self> {
         if let PublicKeyRepr::Ed25519(key) = public_key.inner {
             Ok(solana_sdk::pubkey::Pubkey::new(key.as_ref()))
         } else {


### PR DESCRIPTION
This allows a client to use `TryFrom<PublicKey> for solana_sdk::pubkey::Pubkey` without explicitly importing `solana_sdk` in their `Cargo.toml`.