### PR TITLE
impl pg array type for publickeybin

### DIFF
--- a/src/public_key.rs
+++ b/src/public_key.rs
@@ -438,7 +438,7 @@ mod tests {
     }
 
     fn parse_pubkey(bytes: &[u8; 33]) -> PublicKey {
-        PublicKey::from_bytes(&bytes).expect("failed to parse bytes as publickey")
+        PublicKey::from_bytes(bytes).expect("failed to parse bytes as publickey")
     }
 
     #[test]

--- a/src/public_key_binary.rs
+++ b/src/public_key_binary.rs
@@ -119,13 +119,19 @@ mod sqlx_postgres {
         decode::Decode,
         encode::{Encode, IsNull},
         error::BoxDynError,
-        postgres::{PgArgumentBuffer, PgTypeInfo, PgValueRef, Postgres},
+        postgres::{PgArgumentBuffer, PgHasArrayType, PgTypeInfo, PgValueRef, Postgres},
         types::Type,
     };
 
     impl Type<Postgres> for PublicKeyBinary {
         fn type_info() -> PgTypeInfo {
             PgTypeInfo::with_name("text")
+        }
+    }
+
+    impl PgHasArrayType for PublicKeyBinary {
+        fn array_type_info() -> PgTypeInfo {
+            PgTypeInfo::with_name("_text")
         }
     }
 


### PR DESCRIPTION
Implement the `PgHasArrayType` trait for the `PublicKeyBinary` when the `sqlx-postgres` feature is enabled to allow saving arrays of pubkey binaries to the database. This is currently required for the persistence of the `delegate_keys` assigned to an organization in the IoT Config service to allow orgs to delegate the management of certain network features to a pre-supplied list of approved keys.

Also cleans up a lint error in one of the tests