### PR TITLE
Handle invalid ed25519 signature lengths

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -41,6 +41,7 @@ jobs:
       - name: Test
         uses: actions-rs/tarpaulin@v0.1
         with:
+          version: 0.22.0
           args: "--features multisig,solana -- --test-threads 1"
 
       - name: Upload coverage

--- a/src/ecc_compact/mod.rs
+++ b/src/ecc_compact/mod.rs
@@ -309,6 +309,18 @@ mod tests {
     }
 
     #[test]
+    fn verify_invalid_sig() {
+        // Test a msg signed and verified with a keypair generated with erlang
+        // libp2p_crypto but with a truncated signature
+        const MSG: &[u8] = b"hello world";
+        const PUBKEY: &str = "11nYr7TBMbpGiQadiCxGCPZFZ8ENo1JNtbS7aB5U7UXn4a8Dvb3";
+        const SIG: &[u8] = &hex!("304402206d791eb96bcc7d0ef403bc7a653fd99a6906374ec9");
+
+        let public_key: crate::PublicKey = PUBKEY.parse().expect("b58 public key");
+        assert!(public_key.verify(MSG, SIG).is_err());
+    }
+
+    #[test]
     fn b58_roundtrip() {
         const B58: &str = "112jXiCTi9DpLC5nLdSZ2zccRVEtZizRJMizziCebaNbRDi8k6wR";
         let decoded: crate::PublicKey = B58.parse().expect("b58 public key");

--- a/src/secp256k1/mod.rs
+++ b/src/secp256k1/mod.rs
@@ -327,6 +327,17 @@ mod tests {
     }
 
     #[test]
+    fn verify_invalid_sig() {
+        // Test a msg signed and verified with a keypair generated with erlang crypto
+        // and compressed by hand but with a truncated signature
+        const MSG: &[u8] = b"hello world";
+        const PUBKEY: &str = "1SpLY6fic4fGthLGjeAUdLVNVYk1gJGrWTGhsukm2dnELaSEQmhL";
+        let public_key: crate::PublicKey = PUBKEY.parse().expect("b58 public key");
+        const SIG: &[u8] = &hex!("3045022100b72de78c39ecdb7db78429362bcdea509cd414");
+        assert!(public_key.verify(MSG, SIG).is_err());
+    }
+
+    #[test]
     #[ignore]
     // Test to be skipped until BIP-0062 adjustments to k256 ECDSA are removed
     // from elliptic-curves library.


### PR DESCRIPTION
Unlike the previously used ed25519 crate the ed25519_compact crate panics when it is given a signature that isn’t the right length.

This adds a safeguard (and unittest) to ensure the signature is the correct length