### PR TITLE
Revert rust crypto upgrades

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,14 +13,13 @@ thiserror = "1"
 bs58 = {version = "0.5", features=["check"]}
 base64 = ">=0.21"
 drop_guard = { version = "0.3.0", optional = true }
-signature = "2"
+signature = "1"
 serde =  {version = "1", features=["derive"]}
 rand_core = { version = "0.6", features = ["getrandom"] }
 sha2 = {version = "0.10", default-features=false, features=["std", "oid"] }
-ed25519 = "2"
 ed25519-compact = {version = "2", features = ["std", "traits"] }
-p256 = { version="0.13", default-features=false, features=["arithmetic", "ecdsa", "sha256", "ecdh"] }
-k256 = { version="0.13", default-features=false, features=["arithmetic", "ecdsa", "sha256", "ecdh"] }
+p256 = { version="0.10", default-features=false, features=["arithmetic", "ecdsa", "sha256", "ecdh"] }
+k256 = { version="0.10", default-features=false, features=["arithmetic", "ecdsa", "sha256", "ecdh"] }
 rsa = { version="0.9", optional = true, default-features=false, features=["std"] }
 ecc608-linux = { version = "0", optional = true}
 tss2 = {version = "0", optional = true}

--- a/src/keypair.rs
+++ b/src/keypair.rs
@@ -279,10 +279,7 @@ mod tests {
         let other_shared = other
             .ecdh(key_pair.public_key())
             .expect("other shared secret");
-        assert_eq!(
-            keypair_shared.raw_secret_bytes(),
-            other_shared.raw_secret_bytes()
-        );
+        assert_eq!(keypair_shared.as_bytes(), other_shared.as_bytes());
     }
 
     fn seed_roundtrip(key_tag: KeyTag) {

--- a/src/secp256k1/mod.rs
+++ b/src/secp256k1/mod.rs
@@ -51,7 +51,7 @@ impl TryFrom<&[u8]> for Keypair {
     type Error = super::error::Error;
     fn try_from(input: &[u8]) -> Result<Self> {
         let network = Network::try_from(input[0])?;
-        let secret = k256::SecretKey::from_slice(&input[1..])?;
+        let secret = k256::SecretKey::from_be_bytes(&input[1..])?;
         let public_key =
             public_key::PublicKey::for_network(network, PublicKey(secret.public_key()));
         Ok(Keypair {
@@ -84,7 +84,7 @@ impl Keypair {
     }
 
     pub fn generate_from_entropy(network: Network, entropy: &[u8]) -> Result<Keypair> {
-        let secret = k256::SecretKey::from_slice(entropy)?;
+        let secret = k256::SecretKey::from_be_bytes(entropy)?;
         let public_key = secret.public_key();
         Ok(Keypair {
             network,
@@ -112,6 +112,22 @@ impl Keypair {
     }
 }
 
+impl signature::Signature for Signature {
+    fn from_bytes(input: &[u8]) -> std::result::Result<Self, signature::Error> {
+        Ok(Signature(signature::Signature::from_bytes(input)?))
+    }
+
+    fn as_bytes(&self) -> &[u8] {
+        self.0.as_bytes()
+    }
+}
+
+impl AsRef<[u8]> for Signature {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_ref()
+    }
+}
+
 impl signature::Signer<Signature> for Keypair {
     fn try_sign(&self, msg: &[u8]) -> std::result::Result<Signature, signature::Error> {
         Ok(Signature(self.secret.sign(msg)))
@@ -120,7 +136,7 @@ impl signature::Signer<Signature> for Keypair {
 
 impl Signature {
     pub fn from_be_bytes(bytes: &[u8]) -> Result<Self> {
-        Ok(Signature(ecdsa::Signature::try_from(bytes)?))
+        Ok(Signature(signature::Signature::from_bytes(bytes)?))
     }
 
     pub fn to_vec(&self) -> Vec<u8> {

--- a/src/tpm/mod.rs
+++ b/src/tpm/mod.rs
@@ -74,7 +74,7 @@ impl Keypair {
     where
         C: TryInto<&'a ecc_compact::PublicKey, Error = error::Error>,
     {
-        use p256::elliptic_curve::{group::GroupEncoding, sec1::ToEncodedPoint};
+        use p256::elliptic_curve::sec1::ToEncodedPoint;
         let key = public_key.try_into()?;
         let point = key.0.to_encoded_point(false);
         let x = point.x().unwrap().as_slice();
@@ -88,7 +88,7 @@ impl Keypair {
             .map_err(p256::elliptic_curve::Error::from)?;
         let affine_point = p256::AffinePoint::from_encoded_point(&encoded_point).unwrap();
         Ok(ecc_compact::SharedSecret(p256::ecdh::SharedSecret::from(
-            *p256::FieldBytes::from_slice(affine_point.to_bytes().as_slice()),
+            &affine_point,
         )))
     }
 }


### PR DESCRIPTION
To be compatible with the solana sdk the rust crypto versions around elliptic curve are quite picky. This is the known working rust-crypto release as of solana-sdk 1.14.

This mostly reverts 077ba0db451b4e775531dd8a3df2e0b3e303ff40