### PR TITLE
Fix RSA compiling issue

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ k256 = { version = "0.10", default-features = false, features = [
     "ecdh",
 ] }
 rsa = { version = "0.4", optional = true, default-features = false, features = [
-    "std",
+    "std", "pem"
 ] }
 ecc608-linux = { version = "0", optional = true }
 tss2 = { version = "0", optional = true }


### PR DESCRIPTION
I still have problems with compiling this package.
But it looks like I've found how to fix it. I've tested this locally and it works 

Links
- Issue described in RSA repository https://github.com/RustCrypto/RSA/issues/96 
- My previous issue in this repository https://github.com/helium/helium-crypto-rs/issues/63
- Related problem https://github.com/helium/oracles/pull/625