### PR TITLE
Enfore rsa dependency pin

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ k256 = { version = "0.10", default-features = false, features = [
     "sha256",
     "ecdh",
 ] }
-rsa = { version = "0.4", optional = true, default-features = false, features = [
+rsa = { version = "=0.4", optional = true, default-features = false, features = [
     "std", "pem"
 ] }
 ecc608-linux = { version = "0", optional = true }


### PR DESCRIPTION
Summary
----
- This pins the rsa dependency to be _exactly_ 0.4.
- This is done to ensure that a downstream library which uses helium-crypto as a dependency will _always_ get rsa at 0.4.