### PR TITLE
Make helium-crypto-rs compilable with the latest ed25519-compact version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ serde = { version = "1", features = ["derive"] }
 rand_core = "^0.6"
 getrandom = "0"
 sha2 = { version = "0.10", default-features = false, features = ["std", "oid"] }
-ed25519-compact = { version = "2", features = ["std", "traits"] }
+ed25519-compact = { version = "=2.0.6", features = ["std", "traits"] }
 p256 = { version = "0.10", default-features = false, features = [
     "arithmetic",
     "ecdsa",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ serde = { version = "1", features = ["derive"] }
 rand_core = "^0.6"
 getrandom = "0"
 sha2 = { version = "0.10", default-features = false, features = ["std", "oid"] }
-ed25519-compact = { version = "=2.0.6", features = ["std", "traits"] }
+ed25519-compact = { version = "2", features = ["std", "traits"] }
 p256 = { version = "0.10", default-features = false, features = [
     "arithmetic",
     "ecdsa",

--- a/src/ed25519/mod.rs
+++ b/src/ed25519/mod.rs
@@ -153,7 +153,7 @@ impl TryFrom<&[u8]> for Signature {
     type Error = Error;
 
     fn try_from(input: &[u8]) -> Result<Self> {
-        Signature::from_bytes(input).map_err(Error::from)
+        Signature::from_bytes(input)
     }
 }
 

--- a/src/ed25519/mod.rs
+++ b/src/ed25519/mod.rs
@@ -100,11 +100,13 @@ impl Keypair {
 
 impl signature::Signature for Signature {
     fn from_bytes(input: &[u8]) -> std::result::Result<Self, signature::Error> {
-        Ok(Signature(signature::Signature::from_bytes(input)?))
+        let signature =
+            ed25519_compact::Signature::try_from(input).map_err(signature::Error::from_source)?;
+        Ok(Signature(signature))
     }
 
     fn as_bytes(&self) -> &[u8] {
-        self.0.as_bytes()
+        self.0.as_ref()
     }
 }
 
@@ -138,7 +140,8 @@ impl signature::Signer<Signature> for Keypair {
 
 impl Signature {
     pub fn from_bytes(bytes: &[u8]) -> Result<Self> {
-        Ok(Signature(signature::Signature::from_bytes(bytes)?))
+        let signature = ed25519_compact::Signature::try_from(bytes)?;
+        Ok(Signature(signature))
     }
 
     pub fn to_vec(&self) -> Vec<u8> {
@@ -150,9 +153,7 @@ impl TryFrom<&[u8]> for Signature {
     type Error = Error;
 
     fn try_from(input: &[u8]) -> Result<Self> {
-        signature::Signature::from_bytes(input)
-            .map(Signature)
-            .map_err(Error::from)
+        Signature::from_bytes(input).map_err(Error::from)
     }
 }
 

--- a/src/ed25519/mod.rs
+++ b/src/ed25519/mod.rs
@@ -153,7 +153,8 @@ impl TryFrom<&[u8]> for Signature {
     type Error = Error;
 
     fn try_from(input: &[u8]) -> Result<Self> {
-        Signature::from_bytes(input)
+        let signature = ed25519_compact::Signature::try_from(input)?;
+        Ok(Signature(signature))
     }
 }
 


### PR DESCRIPTION
Fix compiling issue
```
❯ cargo build
   Compiling helium-crypto v0.8.3 (/home/kurotych/Sources/helium-crypto-rs)
error[E0277]: the trait bound `ed25519_compact::Signature: signature::Signature` is not satisfied
   --> src/ed25519/mod.rs:103:22
    |
103 |         Ok(Signature(signature::Signature::from_bytes(input)?))
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `signature::Signature` is not implemented for `ed25519_compact::Signature`
    |
    = help: the following other types implement trait `signature::Signature`:
              ecdsa::der::Signature<C>
              ecdsa::Signature<C>
              ecc_compact::Signature
              ed25519::Signature
              secp256k1::Signature
              k256::ecdsa::recoverable::Signature

error[E0599]: no method named `as_bytes` found for struct `ed25519_compact::Signature` in the current scope
   --> src/ed25519/mod.rs:107:16
    |
107 |         self.0.as_bytes()
    |                ^^^^^^^^ method not found in `Signature`

error[E0277]: the trait bound `ed25519_compact::Signature: signature::Signature` is not satisfied
   --> src/ed25519/mod.rs:141:22
    |
141 |         Ok(Signature(signature::Signature::from_bytes(bytes)?))
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `signature::Signature` is not implemented for `ed25519_compact::Signature`
    |
    = help: the following other types implement trait `signature::Signature`:
              ecdsa::der::Signature<C>
              ecdsa::Signature<C>
              ecc_compact::Signature
              ed25519::Signature
              secp256k1::Signature
              k256::ecdsa::recoverable::Signature

error[E0277]: the trait bound `ed25519_compact::Signature: signature::Signature` is not satisfied
   --> src/ed25519/mod.rs:153:9
    |
153 |         signature::Signature::from_bytes(input)
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `signature::Signature` is not implemented for `ed25519_compact::Signature`
    |
    = help: the following other types implement trait `signature::Signature`:
              ecdsa::der::Signature<C>
              ecdsa::Signature<C>
              ecc_compact::Signature
              ed25519::Signature
              secp256k1::Signature
              k256::ecdsa::recoverable::Signature
 ```