### PR TITLE
Update past sqlx 0.7 to 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ lazy_static = "1.4.0"
 libc = { version = "0", optional = true }
 byteorder = { version = "1", optional = true }
 multihash = { version = "0.18", optional = true }
-sqlx = { version = "^0.7", optional = true, default-features = false }
+sqlx = { version = "^0.8", optional = true, default-features = false }
 solana-sdk = { version = ">= 2.2", optional = true }
 uuid = { version = "1", features = ["v4", "fast-rng"], optional = true }
 

--- a/src/public_key.rs
+++ b/src/public_key.rs
@@ -207,7 +207,10 @@ mod sqlx_postgres {
     }
 
     impl Encode<'_, Postgres> for PublicKey {
-        fn encode_by_ref(&self, buf: &mut PgArgumentBuffer) -> IsNull {
+        fn encode_by_ref(
+            &self,
+            buf: &mut PgArgumentBuffer,
+        ) -> std::result::Result<IsNull, BoxDynError> {
             let address = self.to_string();
             Encode::<Postgres>::encode(&address, buf)
         }

--- a/src/public_key_binary.rs
+++ b/src/public_key_binary.rs
@@ -136,7 +136,10 @@ mod sqlx_postgres {
     }
 
     impl Encode<'_, Postgres> for PublicKeyBinary {
-        fn encode_by_ref(&self, buf: &mut PgArgumentBuffer) -> IsNull {
+        fn encode_by_ref(
+            &self,
+            buf: &mut PgArgumentBuffer,
+        ) -> std::result::Result<IsNull, BoxDynError> {
             let address = self.to_string();
             Encode::<Postgres>::encode(&address, buf)
         }


### PR DESCRIPTION
Sqlx 0.7.x proved to be a short-lived series of versions with many breaking changes introduced between 0.7-0.8 which has now been out for some time.

This has been tested fully downstream from the sqlx-postgres features in this repo to helium-lib to oracles to two additional layers deeper of internal projects each consuming those in turn.